### PR TITLE
chore(design): add CSS scope on co-list

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,6 +23,7 @@ var config = {
     './src/styles/**/*.scss',
     './node_modules/bootstrap-sass/assets/stylesheets/**/*.scss',
     './node_modules/font-awesome/scss/**/*.scss',
+    './node_modules/angular-pseudo-class/lib/scss/**/*.scss',
   ],
   vendorFiles: [
   ],

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "angular": "~1.4.8",
     "angular-mocks": "~1.4.8",
     "angular-moment": "^0.10.3",
+    "angular-pseudo-class": "^0.1.9",
     "angular-sanitize": "^1.4.8",
     "angular-translate": "^2.8.1",
     "angular-translate-loader-static-files": "^2.8.1",

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -13,6 +13,7 @@ import uiSlider from 'angular-ui-slider';
 import ngRedux from 'ng-redux';
 import reduxUiRouter from 'redux-ui-router';
 import angularMoment from 'angular-moment';
+import pseudoClass from 'angular-pseudo-class';
 
 let app = angular.module('caliopenApp', [
   uiRouter,
@@ -22,6 +23,7 @@ let app = angular.module('caliopenApp', [
   ngRedux,
   angularMoment.name,
   reduxUiRouter,
+  pseudoClass,
 ]);
 
 // config

--- a/src/js/directive/contacts.js
+++ b/src/js/directive/contacts.js
@@ -23,7 +23,7 @@ export function ContactsDirective() {
     bindToController: true,
     template: `
     <div class="container-fluid co-list">
-      <div ng-repeat="contact in ctrl.contacts" ng-click="ctrl.show(contact)" class="row co-list__item co-list__item--link">
+      <div ng-repeat="contact in ctrl.contacts" ng-click="ctrl.show(contact)" class="row co-list__item co-list__item--link" pseudo-class-ctrl>
         <div class="row__vertical-align">
           <div class="col-xs-12 col-sm-5">
             <span class="co-contacts__contact-icon">
@@ -34,19 +34,21 @@ export function ContactsDirective() {
             </span>
           </div>
           <div class="hidden-xs col-sm-7">
-            <span class="co-text--ellipsis">
-              {{contact.emails[0]}}
-            </span>
-            <span class="dropdown">
-              <span class="dropdown-toggle" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                <span class="caret"></span>
+            <span pseudo-class-scope>
+              <span class="co-text--ellipsis">
+                {{contact.emails[0]}}
               </span>
-              <ul class="dropdown-menu pull-right">
-                <li ng-repeat="email in contact.emails">
-                  <i class="fa fa-envelope"></i>
-                  {{email.address}}
-                </li>
-              </ul>
+              <span class="dropdown">
+                <span class="dropdown-toggle" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                  <span class="caret"></span>
+                </span>
+                <ul class="dropdown-menu pull-right">
+                  <li ng-repeat="email in contact.emails">
+                    <i class="fa fa-envelope"></i>
+                    {{email.address}}
+                  </li>
+                </ul>
+              </span>
             </span>
           </div>
         </div>

--- a/src/styles/components/_list.scss
+++ b/src/styles/components/_list.scss
@@ -15,11 +15,11 @@
   .co-list__item--link {
     cursor: pointer;
 
-    &:hover {
+    @include pseudo-class(hover) {
       background-color: $co-color-fg--high;
       color: $co-color-fg-text--high;
     }
-    &:active {
+    @include pseudo-class(active) {
       background-color: $co-color-fg--low;
       color: $co-color-fg-text--low;
     }

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -6,6 +6,7 @@
 // vendors
 @import "bootstrap";
 @import "font-awesome";
+@import "angular-pseudo-class";
 
 // vendors extentions
 @import "bootstrap-extention/grid";


### PR DESCRIPTION
Use angular-pseudo-class to make a "CSS pseudo-classes scope" on `.co-list` : prevent the items inside the list with their own interactions to trigger the list itself. (visual effect only).

Preview:
![Preview](http://img15.hostingpics.net/pics/456824contactlisthover.jpg)