### PR TITLE
fix(design): prevent Bootstrap font-size reset

### DIFF
--- a/src/styles/bootstrap-extention/_scaffolding.scss
+++ b/src/styles/bootstrap-extention/_scaffolding.scss
@@ -1,0 +1,6 @@
+html {
+  // Prevent BS font-size reset.
+  // Base font-size should be given by the browser
+  // https://teamtreehouse.com/community/note-bootstrap-may-reset-your-base-fontsize
+  font-size: 100%;
+}

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -10,6 +10,7 @@
 
 // vendors extentions
 @import "bootstrap-extention/grid";
+@import "bootstrap-extention/scaffolding";
 
 // components
 @import "components/avatar";


### PR DESCRIPTION
Base font-size should be given by the browser, for accessibility reasons.
https://teamtreehouse.com/community/note-bootstrap-may-reset-your-base-fontsize
