### PR TITLE
refactor(design): standardize color palette

### DIFF
--- a/src/styles/base/_bootstrap.scss
+++ b/src/styles/base/_bootstrap.scss
@@ -1,20 +1,20 @@
 // --- base ---
 // colors
-$gray-base:     $caliopen-color-1;
+$gray-base:     #ffffff;
 $gray-lighter:  darken($gray-base, 13.5%);
 $gray-light:    darken($gray-base, 20%);
 $gray:          darken($gray-base, 33.5%);
 $gray-dark:     darken($gray-base, 46.7%);
 $gray-darker:   darken($gray-base, 93.5%);
-$brand-primary: $caliopen-color-4;
+$brand-primary: $co-color__primary;
 
 // fonts
 $font-family-sans-serif: open_sansregular, "Helvetica Neue", Helvetica, Arial, sans-serif;
 
 
 // --- layout ---
-$body-bg: #1d1d1d;
-$body-color: $caliopen-color-1;
+$body-bg: $co-color__bg__back;
+$text-color: $co-color__bg__text;
 
 
 // --- components ---
@@ -22,22 +22,23 @@ $border-radius-base: 0px;
 $border-radius-small: 0px;
 $border-radius-large: 0px;
 
-$component-active-bg: $caliopen-color-4;
-$component-active-color: $gray-light;
+$component-active-bg: $co-color__primary;
+$component-active-color: $co-color__fg__text;
 
 // dropdown
-$dropdown-bg: #333333;
-$dropdown-link-hover-bg: lighten($caliopen-color-4, 5);
-$dropdown-divider-bg: $caliopen-color-2;
+$dropdown-bg: $co-color__fg__back;
+$dropdown-link-hover-bg: $co-color__primary;
+$dropdown-divider-bg: $co-color__fg__back;
 
-$dropdown-link-color: $gray-lighter;
-$dropdown-link-disabled-color: $gray-darker;
-$dropdown-link-hover-color: lighten($gray-lighter, 5%);
+$dropdown-link-color: $co-color__fg__text--higher;
+$dropdown-link-disabled-color: $co-color__fg__text--lower;
+$dropdown-link-hover-color: $co-color__fg__text;
 
 // navbar
-$navbar-inverse-bg: $caliopen-color-2;
-$navbar-inverse-link-active-bg: $caliopen-color-3;
-$navbar-inverse-link-hover-bg: lighten($caliopen-color-4, 5);
+$navbar-inverse-bg: $co-color__fg__back;
+$navbar-inverse-link-active-bg: $co-color__primary--lower;
+$navbar-inverse-link-hover-bg: $co-color__primary;
 
 // badge
-$badge-bg: $gray-darker;
+$badge-bg: $co-color__fg__back--high;
+$badge-color: $co-color__fg__text--low;

--- a/src/styles/base/_colors.scss
+++ b/src/styles/base/_colors.scss
@@ -1,7 +1,10 @@
+// --- Standard ---
 // bright colors
 $co-color__primary:           #1395ba;
+$co-color__primary--lower:    darken($co-color__primary, 15%);
 $co-color__primary--low:      darken($co-color__primary, 10%);
 $co-color__primary--high:     lighten($co-color__primary, 10%);
+$co-color__primary--higher:   lighten($co-color__primary, 15%);
 
 $co-color__secondary:         #13ba95;
 $co-color__secondary--low:    darken($co-color__secondary, 10%);
@@ -31,19 +34,14 @@ $co-color__bg__border:        #ffffff;
 $co-color__bg__border--low:   darken($co-color__bg__border, 10%);
 $co-color__bg__border--high:  lighten($co-color__bg__border, 10%);
 
-$co-color__bg__text:          #ffffff;
+$co-color__bg__text:          #888888;
 $co-color__bg__text--lower:   darken($co-color__bg__text, 30%);
 $co-color__bg__text--low:     darken($co-color__bg__text, 15%);
 $co-color__bg__text--high:    lighten($co-color__bg__text, 10%);
 $co-color__bg__text--higher:  lighten($co-color__bg__text, 20%);
 
 
-// basic palette
-$caliopen-color-1: #ffffff;
-$caliopen-color-2: #333333;
-$caliopen-color-3: #294f5c;
-$caliopen-color-4: #3386a2;
-$caliopen-color-5: #97b707;
-
-$importance-color: #d2bc00;
-$privacy-color: $caliopen-color-5;
+// --- Custom ---
+// semantic colors
+$co-color__importance:        #d2bc00;
+$co-color__privacy:           #97b707;

--- a/src/styles/components/_avatars.scss
+++ b/src/styles/components/_avatars.scss
@@ -9,7 +9,7 @@ $co-avatars-letter-padding-size: 0px;
   width: $co-avatars-radius;
   height: $co-avatars-radius;
 
-  background-color: $caliopen-color-3;
+  background-color: $co-color__primary--low;
   border-radius: 50%;
   overflow: hidden;
 

--- a/src/styles/components/_slider.scss
+++ b/src/styles/components/_slider.scss
@@ -41,11 +41,11 @@
 }
 
 .co-layout__body__block-importance {
-  @include co-slider($importance-color, top);
+  @include co-slider($co-color__importance, top);
 }
 
 .co-layout__topbar__block-privacy {
-  @include co-slider($privacy-color, left);
+  @include co-slider($co-color__privacy, left);
 }
 
 .co-layout {

--- a/src/styles/layout/_body.scss
+++ b/src/styles/layout/_body.scss
@@ -12,7 +12,7 @@
   }
 
   &__content {
-    background-color: $caliopen-color-2;
+    background-color: $co-color__fg__back;
     padding-top: 45px;
   }
 }

--- a/src/styles/layout/_tabs.scss
+++ b/src/styles/layout/_tabs.scss
@@ -1,5 +1,5 @@
 .co-layout__tabs {
-  background-color: $body-bg;
+  background-color: $co-color__bg__back;
   margin-bottom: 0;
   padding-left: 0;
   list-style: none;
@@ -23,10 +23,10 @@
 }
 
 .co-layout__tabs__item__link {
-  color: darken($caliopen-color-1, 50);
-  border-bottom: 4px solid $body-bg;
-  border-top: 4px solid $body-bg;
-  background-color: $caliopen-color-2;
+  color: $co-color__fg__text--lower;
+  border-bottom: 4px solid $co-color__bg__back;
+  border-top: 4px solid $co-color__bg__back;
+  background-color: $co-color__fg__back;
   margin-right: 2px;
   position: relative;
   display: block;
@@ -42,11 +42,11 @@
   &:focus {
     //reset bootstrap
     text-decoration: none;
-    color: darken($caliopen-color-1, 30);
+    color: $co-color__fg__text;
   }
 
   &--active {
-    color: $caliopen-color-1;
+    color: $co-color__fg__text--higher;
     border-bottom: 4px solid transparent;
     border-top: 4px solid transparent;
   }

--- a/src/styles/pages/_messages.scss
+++ b/src/styles/pages/_messages.scss
@@ -10,7 +10,7 @@
 }
 
 .caliopen-messages__message--summary:hover {
-  color: lighten($caliopen-color-1, 5);
+  color: $co-color__fg__text--high;
   cursor: pointer;
 }
 

--- a/src/styles/pages/_threads.scss
+++ b/src/styles/pages/_threads.scss
@@ -1,9 +1,9 @@
-$co-threads-read-color: darken($caliopen-color-1, 40);
-$co-threads-unread-color: lighten($caliopen-color-2, 30);
+$co-threads-read-color: $co-color__fg__back;
+$co-threads-unread-color: lighten($co-color__fg__back, 30);
 
 .caliopen-threads__thread {
   height: 80px;
-  border-bottom: 1px solid $body-bg;
+  border-bottom: 1px solid $co-color__bg__back;
   padding: 10px 0;
 
   a {
@@ -14,14 +14,14 @@ $co-threads-unread-color: lighten($caliopen-color-2, 30);
   }
 }
 .caliopen-threads__thread:first-child {
-  border-top: 1px solid $body-bg;
+  border-top: 1px solid $co-color__bg__back;
 }
 
 .caliopen-threads__thread--unread {
   background-color: $co-threads-unread-color;
-  color: $caliopen-color-1;
+  color: $co-color__fg__text--higher;
   a {
-    color: $caliopen-color-1;
+    color: $co-color__fg__text--higher;
   }
 
   .contact-icon {
@@ -46,6 +46,7 @@ $co-threads-unread-color: lighten($caliopen-color-2, 30);
 
   .caliopen-threads__thread__nb-messages {
     &.badge {
-      color: $co-threads-read-color;
+      background: $co-color__bg__back;
+      color: $co-color__bg__text;
     }
   }


### PR DESCRIPTION
:ok_hand:  Refactor, no color have been visually changed (minor invisible changes possibles).

Changes:
 - Include in color palette importance and privacy colors.
 - Use colors palette everywhere instead of custom colors and shades.

Exceptions:
 - letters backgrounds
 - threads unread background (not in color palette: too light. It will be changed in a future commit)