### PR TITLE
refactor(various): simplify Application Helper

### DIFF
--- a/src/js/directive/layout/application-switcher.js
+++ b/src/js/directive/layout/application-switcher.js
@@ -2,9 +2,8 @@ export class LayoutApplicationSwitcherController {
   constructor($scope, $ngRedux, ApplicationHelper) {
     'ngInject';
     $scope.$on('$destroy', $ngRedux.connect(() => {
-      let {name, route} = ApplicationHelper.getInfoForCurrentState();
       return {
-        currentApplication: name,
+        currentApplication: ApplicationHelper.getCurrentInfos().name,
       };
     })(this));
   }

--- a/src/js/directive/layout/application-switcher.js
+++ b/src/js/directive/layout/application-switcher.js
@@ -4,8 +4,7 @@ export class LayoutApplicationSwitcherController {
     $scope.$on('$destroy', $ngRedux.connect(() => {
       let {name, route} = ApplicationHelper.getInfoForCurrentState();
       return {
-        currentApplicationKey: `header.menu.${name}`,
-        currentApplicationRoute: route
+        currentApplication: name,
       };
     })(this));
   }
@@ -20,25 +19,17 @@ export function LayoutApplicationSwitcherDirective() {
     bindToController: true,
     template: `
       <ul class="nav navbar-nav">
-        <li class="dropdown">
-          <a href class="dropdown-toggle" data-toggle="dropdown"
-             role="button" aria-haspopup="true" aria-expanded="false">
-            {{ctrl.currentApplicationKey | translate}} <span class="caret"></span>
+        <li ng-class="{active: (ctrl.currentApplication === 'discussions')}">
+          <a ui-sref="front.discussions">
+            <i class="fa fa-envelope"></i>
+            {{ 'header.menu.discussions'|translate}}
           </a>
-          <ul class="dropdown-menu">
-            <li>
-              <a ui-sref="front.discussions">
-                <i class="fa fa-envelope"></i>
-                {{ 'header.menu.discussions'|translate}}
-              </a>
-            </li>
-            <li>
-              <a ui-sref="front.contacts">
-                <i class="fa fa-users"></i>
-                {{ 'header.menu.contacts'|translate}}
-              </a>
-            </li>
-          </ul>
+        </li>
+        <li ng-class="{active: (ctrl.currentApplication === 'contacts')}">
+          <a ui-sref="front.contacts">
+            <i class="fa fa-users"></i>
+            {{ 'header.menu.contacts'|translate}}
+          </a>
         </li>
       </ul>`
   };

--- a/src/js/directive/layout/application-wrapper.js
+++ b/src/js/directive/layout/application-wrapper.js
@@ -13,9 +13,8 @@ class LayoutApplicationWrapperController {
     'ngInject';
     $scope.$on('$destroy',$ngRedux.connect(routerSelector)(this));
     $scope.$on('$destroy', $ngRedux.connect(() => {
-      let {name, route} = ApplicationHelper.getInfoForCurrentState();
       return {
-        currentApplication: name,
+        currentApplication: ApplicationHelper.getCurrentInfos().name,
       };
     })(this));
   }

--- a/src/js/directive/layout/tab-list.js
+++ b/src/js/directive/layout/tab-list.js
@@ -14,7 +14,7 @@ export class LayoutTabListController {
     this.$ngRedux = $ngRedux;
     this.TabsActions = TabsActions;
     $scope.$on('$destroy', $ngRedux.connect(() => {
-      let {name, route} = ApplicationHelper.getInfoForCurrentState();
+      let {name, route} = ApplicationHelper.getCurrentInfos();
       return {
         currentApplicationKey: `header.menu.${name}`,
         currentApplicationRoute: route

--- a/src/js/service/helper/application-helper.js
+++ b/src/js/service/helper/application-helper.js
@@ -1,5 +1,7 @@
-export const APPLICATION_DISCUSSIONS = 'discussions';
-export const APPLICATION_CONTACTS = 'contacts';
+export const ApplicationRoutes = {
+  discussions: 'front.discussions',
+  contacts: 'front.contacts'
+};
 
 export class ApplicationHelper {
   constructor($state) {
@@ -7,22 +9,13 @@ export class ApplicationHelper {
     this.$state = $state;
   }
 
-  getInfoForCurrentState() {
-    let name, route;
-    switch(true) {
-      case (this.$state.includes('front.discussions')):
-        name = APPLICATION_DISCUSSIONS;
-        route = 'front.discussions';
-        break;
-      case (this.$state.includes('front.contacts')):
-        name = APPLICATION_CONTACTS;
-        route = 'front.contacts';
-        break;
-    }
-
-    return {
+  getCurrentInfos() {
+    let name = Object.keys(ApplicationRoutes).find(
+      name => this.$state.includes( ApplicationRoutes[name] )
+    );
+    return ({
       name,
-      route
-    };
+      route: ApplicationRoutes[name]
+    });
   }
 }


### PR DESCRIPTION
Simplify ApplicationHelper and its use.

Changes on ApplicationHelper:
 - Use loop on object instead of switch
 - Add getCurrentApplication(): return App state name

Other changes:
 - Use getCurrentApplication() in App switcher/wrapper instead of
getInfoForCurrentState()

Require:
- [ ] https://github.com/CaliOpen/caliopen.web-client-ng/pull/38