### PR TITLE
refactor(test): fix and add unit tests

### DIFF
--- a/test/unit/directive/discussions/contact-icon-spec.js
+++ b/test/unit/directive/discussions/contact-icon-spec.js
@@ -22,7 +22,7 @@ describe('Directive Discussions contactIcon', () => {
       { title: 'Bender'},
     ] } });
     expect(ctrl.lettersStylesheetClass).toEqual(['co-letter--P', 'co-letter--L', 'co-letter--B']);
-    expect(ctrl.iconClass).toEqual('contact-icon__letter--3')
+    expect(ctrl.iconClass).toEqual('co-avatars__letter--3')
   });
   it('thread has 4 contacts', inject((ThreadRepository, MessageRepository) => {
     let ctrl = getController({ thread: { contacts: [
@@ -32,7 +32,7 @@ describe('Directive Discussions contactIcon', () => {
       { title: 'Fry' },
     ] } });
     expect(ctrl.lettersStylesheetClass).toEqual(['co-letter--P', 'co-letter--L', 'co-letter--B', 'co-letter--F']);
-    expect(ctrl.iconClass).toEqual('contact-icon__letter--4')
+    expect(ctrl.iconClass).toEqual('co-avatars__letter--4')
   }));
   it('thread has many contacts', inject((ThreadRepository, MessageRepository) => {
     let ctrl = getController({ thread: { contacts: [
@@ -43,6 +43,6 @@ describe('Directive Discussions contactIcon', () => {
       { title: 'Dr Zoïdberg'},
     ] } });
     expect(ctrl.lettersStylesheetClass).toEqual(['co-letter--P', 'co-letter--L', 'co-letter--B', 'co-letter--plus']);
-    expect(ctrl.iconClass).toEqual('contact-icon__letter--4')
+    expect(ctrl.iconClass).toEqual('co-avatars__letter--4')
   }));
 });

--- a/test/unit/directive/layout/applications-switcher-spec.js
+++ b/test/unit/directive/layout/applications-switcher-spec.js
@@ -7,29 +7,23 @@ describe('Directive Layout Application Switcher', () => {
     angular.module('caliopenApp-test', ['caliopenApp'])
       .controller('LayoutApplicationSwitcherController', LayoutApplicationSwitcherController);
     angular.mock.module('caliopenApp-test', ($provide, $translateProvider) => {
-      $provide.service('$state', () => {
-        return {
-          includes: () => true,
-          go: () => true
-        };
-      });
 
       $translateProvider.translations('en', {});
       $translateProvider.preferredLanguage('en');
     });
   });
 
-  beforeEach(inject(($controller, $state, $ngRedux, ApplicationActions) => {
+  beforeEach(inject(($controller, $ngRedux) => {
     getController = (scope, bindToController = {}) => {
-      console.log(scope);
-      return $controller('LayoutApplicationSwitcherController', { $scope: scope, $state, $ngRedux, ApplicationActions }, bindToController);
+      return $controller('LayoutApplicationSwitcherController', { $scope: scope, $ngRedux }, bindToController);
     };
   }));
 
   it('application is set', inject(($rootScope) => {
     let scope = $rootScope.$new();
     let ctrl = getController(scope, { });
-    expect(ctrl.currentApplicationKey).toEqual('header.menu.discussions');
-    expect(ctrl.currentApplicationRoute).toEqual('front.discussions');
+    $rootScope.$digest();
+
+    expect(ctrl.currentApplication).toEqual('discussions');
   }));
 });

--- a/test/unit/directive/layout/tab-list-spec.js
+++ b/test/unit/directive/layout/tab-list-spec.js
@@ -1,7 +1,8 @@
 import {LayoutTabListController} from '../../../../src/js/directive/layout/tab-list.js';
+import {v1 as uuidV1} from 'uuid';
 
 describe('Directive Layout TabList', () => {
-  let getController;
+  let getController, fakeTab1, fakeTab2;
 
   beforeEach(() => {
     angular.module('caliopenApp-test', ['caliopenApp'])
@@ -17,6 +18,15 @@ describe('Directive Layout TabList', () => {
     getController = (scope, bindToController = {}) => {
       return $controller('LayoutTabListController', { $scope: scope, $state, $ngRedux, TabsActions }, bindToController);
     };
+
+    fakeTab1  = {
+      id: uuidV1(),
+      route: 'front.discussions',
+    };
+    fakeTab2  = {
+      id: uuidV1(),
+      route: 'front.contacts',
+    };
   }));
 
   describe('constructor', () => {
@@ -27,21 +37,23 @@ describe('Directive Layout TabList', () => {
     }));
 
     it('has tabs', inject(($rootScope, $ngRedux, TabsActions) => {
-      $ngRedux.dispatch(TabsActions.createTab({foo: 'bar'}));
-      $ngRedux.dispatch(TabsActions.createTab({foo: 'barbar'}));
+      $ngRedux.dispatch(TabsActions.addTab( fakeTab1 ));
+      $ngRedux.dispatch(TabsActions.addTab( fakeTab2 ));
+
       let scope = $rootScope.$new();
       let ctrl = getController(scope);
-      expect(ctrl.tabs).toEqual([{foo: 'bar'}, {foo: 'barbar'}]);
+      expect(ctrl.tabs).toEqual([ fakeTab1 ,  fakeTab2 ]);
     }));
   });
 
   it('remove', inject(($rootScope, $ngRedux, TabsActions) => {
-    let tab = {foo: 'bar'};
-    $ngRedux.dispatch(TabsActions.createTab(tab));
-    $ngRedux.dispatch(TabsActions.createTab({foo: 'barbar'}));
+    let tab =  fakeTab1 ;
+    $ngRedux.dispatch(TabsActions.addTab(tab));
+    $ngRedux.dispatch(TabsActions.addTab( fakeTab2 ));
+
     let scope = $rootScope.$new();
     let ctrl = getController(scope);
     ctrl.remove(tab);
-    expect(ctrl.tabs).toEqual([{ foo: 'barbar' }]);
+    expect(ctrl.tabs).toEqual([ fakeTab2 ]);
   }));
 });

--- a/test/unit/service/helper/application-helper-spec.js
+++ b/test/unit/service/helper/application-helper-spec.js
@@ -1,0 +1,43 @@
+import {ApplicationHelper} from '../../../../src/js/service/helper/application-helper.js';
+
+describe('Service Helper ApplicationHelper', () => {
+  beforeEach(() => {
+    angular.module('caliopenApp-test', ['caliopenApp'])
+      .service('ApplicationHelper', ApplicationHelper);
+    angular.mock.module('caliopenApp-test', ($translateProvider) => {
+
+      $translateProvider.translations('en', {});
+      $translateProvider.preferredLanguage('en');
+    });
+  });
+
+  let applicationHelper, $state, $rootScope;
+
+  beforeEach(inject((_ApplicationHelper_, _$state_, _$rootScope_) => {
+    applicationHelper = _ApplicationHelper_;
+    $state = _$state_;
+    $rootScope = _$rootScope_;
+  }));
+
+  describe('getCurrentInfos', () => {
+
+    it('give default state infos', () => {
+      $rootScope.$digest();
+
+      expect(applicationHelper.getCurrentInfos()).toEqual({
+        name: 'discussions',
+        route: 'front.discussions'
+      });
+    });
+
+    it('give current state infos', () => {
+      $state.go('front.contacts');
+      $rootScope.$digest();
+
+      expect(applicationHelper.getCurrentInfos()).toEqual({
+        name: 'contacts',
+        route: 'front.contacts'
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Changes
ContactsIcon:
- fix excepted CSS class name

LayoutApplicationSwitcher:
- remove unused `$state` and `console.log`
- fix watched attributes
- wait for the default route to be loaded

LayoutTabList:
- fix tab creation method name

Add ApplicationHelper unit tests. Except it:
- `give default state infos` (with the default route)
- `give current state infos` (after the route changed)

### Note
~~`LayoutTabList` still have errors, but I think it come from the code itself, not the tests.~~ (fixed)

### :warning: Require
- [x] Pull Request https://github.com/CaliOpen/caliopen.web-client-ng/pull/39