### PR TITLE
	feat(design): clean and improve discussion list design

### DIFF
--- a/src/js/directive/discussions.js
+++ b/src/js/directive/discussions.js
@@ -22,7 +22,7 @@ export function DiscussionsDirective() {
     controllerAs: 'ctrl',
     bindToController: true,
     template: `
-      <div class="container-fluid">
+      <div class="container-fluid co-list">
         <co-discussions-thread thread="thread" ng-repeat="thread in ctrl.threads"></co-discussions-thread>
       </div>`
   };

--- a/src/js/directive/discussions/thread.js
+++ b/src/js/directive/discussions/thread.js
@@ -32,14 +32,14 @@ export function DiscussionsThreadDirective() {
     controllerAs: 'ctrl',
     bindToController: true,
     template: `
-      <div ng-click="ctrl.showThread()" class="row caliopen-threads__thread" ng-class="{ 'caliopen-threads__thread--unread': ctrl.hasUnread }">
+      <div ng-click="ctrl.showThread()" class="row co-list__item co-list__item--link co-threads__thread" ng-class="{ 'co-threads__thread--unread': ctrl.hasUnread }">
         <div class="col-md-1 col-sm-1 col-xs-2">
           <co-discussions-contacts-icon thread="ctrl.thread"></co-discussions-contacts-icon>
         </div>
         <div class="col-md-6 col-sm-8 col-xs-9">
-          <span class="caliopen-threads__thread__message-summary">
+          <div class="co-text--ellipsis">
             {{ctrl.thread.text}}
-          </span>
+          </div>
         </div>
         <div class="col-md-1 col-sm-1 col-xs-1">
           <i ng-if="ctrl.thread.file_attached" class="fa fa-paperclip"></i>
@@ -52,7 +52,7 @@ export function DiscussionsThreadDirective() {
           {{ ctrl.fakeDate | amDateFormat:'lll'}}
         </div>
         <div class="col-md-1 hidden-sm hidden-xs">
-          <span class="caliopen-threads__thread__nb-messages badge">
+          <span class="co-threads__thread__nb-messages badge">
             <span ng-if="ctrl.thread.unread_count">{{ctrl.thread.unread_count}}/</span>
             <span>{{ctrl.thread.total_count}}</span>
           </span>

--- a/src/styles/page/_threads.scss
+++ b/src/styles/page/_threads.scss
@@ -1,52 +1,26 @@
-$co-threads-read-color: $co-color__fg__back;
-$co-threads-unread-color: lighten($co-color__fg__back, 30);
-
-.caliopen-threads__thread {
-  height: 80px;
-  border-bottom: 1px solid $co-color__bg__back;
-  padding: 10px 0;
-
-  a {
-    color: $co-threads-read-color;
-  }
-  a:hover {
-    text-decoration: none;
-  }
-}
-.caliopen-threads__thread:first-child {
-  border-top: 1px solid $co-color__bg__back;
-}
-
-.caliopen-threads__thread--unread {
-  background-color: $co-threads-unread-color;
-  color: $co-color__fg__text--higher;
-  a {
+.co-threads__thread {
+  &--unread {
+    position: relative;
+    background-color: $co-color__fg__back--higher;
     color: $co-color__fg__text--higher;
-  }
 
-  .contact-icon {
-    .circle {
-      border-color: $co-threads-unread-color;
+    &::before {
+        content: "";
+        display: block;
+
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        width: 3px;
+
+        background: $co-color__primary;
     }
   }
-}
 
-  .caliopen-threads__thread__contacts {
-    display: block;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-  .caliopen-threads__thread__message-summary {
-    display: block;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
-  .caliopen-threads__thread__nb-messages {
+  &__nb-messages {
     &.badge {
       background: $co-color__bg__back;
       color: $co-color__bg__text;
     }
   }
+}


### PR DESCRIPTION
**Design change**:
- Reduce unread contrast
- Add a blue border for unread discussion

**SCSS clean**:
- Use `.co-list` and `co-text--ellipsis` instead of a custom list
- Remove unused properties
- Use `co-` prefix instead of `caliopen-`

:warning: **Require**:
- [x] https://github.com/CaliOpen/caliopen.web-client-ng/pull/42

**Preview**:
![preview](http://img15.hostingpics.net/pics/533904ScreenShot20160307at094610.png)