### PR TITLE
feat(design): clean and improve message list design

### DIFF
--- a/src/js/directive/thread.js
+++ b/src/js/directive/thread.js
@@ -34,7 +34,7 @@ export function ThreadDirective() {
     controllerAs: 'ctrl',
     bindToController: true,
     template: `
-      <div class="container-fluid">
+      <div class="co-list">
         <co-thread-message ng-repeat="message in ctrl.messages" message="message"></co-thread-message>
       </div>`
   };

--- a/src/js/directive/thread/message.js
+++ b/src/js/directive/thread/message.js
@@ -12,32 +12,28 @@ export function ThreadMessageDirective() {
     controllerAs: 'ctrl',
     bindToController: true,
     template: `
-      <div class="row caliopen-messages__message">
-        <div class="col-xs-2 col-sm-1">
+      <div class="co-list__item co-messages__message__header clearfix">
+        <div class="co-messages__message__contact-icon pull-left">
           <widget-contact-avatar-letter contact="{ address: ctrl.message.from_ }"></widget-contact-avatar-letter>
         </div>
-        <div class="caliopen-messages__message--summary">
-          <div class="col-xs-8 col-sm-4 col-md-6 caliopen-messages__message__subject">
-            <span>{{ ctrl.message.from_ }},</span>
-            <span class="hidden-xs">{{ ctrl.message.subject }}</span>
+        <span class="pull-left">
+          <div class="co-text--ellipsis">
+            {{ ctrl.message.from_ }}
           </div>
-          <div class="col-xs-9 col-sm-3 col-md-2 caliopen-messages__message--summary">
-            {{ ctrl.message.date | amDateFormat:'lll'}}
+          <div class="co-messages__message__summary">
+            {{ ctrl.message.date | amDateFormat:'lll'}} 
           </div>
-          <div class="col-xs-1 caliopen-messages__message--summary">
-            <i ng-if="ctrl.thread.file_attached" class="fa fa-paperclip"></i>
-          </div>
-          <div class="col-xs-4 col-sm-2 col-md-1 caliopen-messages__message--summary">
+        </span>
+        <span class="co-messages__message--summary pull-right">
+          <i ng-if="ctrl.thread.file_attached" class="fa fa-paperclip"></i>
+          <span class="hidden-xs">
             <i class="fa fa-exclamation-triangle"></i> {{ctrl.message.importance_level}}
             <i class="fa fa-eye"></i> {{ctrl.message.privacy_index}}
-          </div>
-          <span class="col-xs-12 hidden-sm hidden-md hidden-lg caliopen-messages__message__subject caliopen-messages__message--summary">
-            {{ctrl.message.subject}}
           </span>
-        </div>
-        <div class="col-xs-12 col-sm-11 caliopen-messages__message__message-body">
-          <div ng-bind-html="ctrl.message.text"></div>
-        </div>
+        </span>
+      </div>
+      <div class="co-list__item co-messages__message__body">
+        <div ng-bind-html="ctrl.message.text"></div>
       </div>`
   };
 }

--- a/src/styles/page/_messages.scss
+++ b/src/styles/page/_messages.scss
@@ -1,28 +1,27 @@
-.caliopen-messages__message {
-  border-bottom: 1px solid $body-bg;
-  min-height: 60px;
-  margin-top: 20px;
-  padding-bottom: 10px;
-}
+.co-messages__message {
+  &__header {
+    padding: ($co-margin / 2) $co-margin;
 
-.caliopen-messages__message--summary {
-  transition: color .3s ease-out;
-}
+    background: $co-color__fg__back--higher;
+    border-bottom: 1px solid $co-color__fg__border--lower;
+  }
 
-.caliopen-messages__message--summary:hover {
-  color: $co-color__fg__text--high;
-  cursor: pointer;
-}
+  &__contact-icon {
+    margin-right: $co-margin;
+  }
 
-.caliopen-messages__message__subject {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
+  &__summary {
+    cursor: pointer;
+    color: $co-color__fg__text--low;
+    font-size: .75rem;
 
-.caliopen-messages__message__message-body {
-  overflow: hidden;
-  margin-top: 10px;
-  text-overflow: ellipsis;
-  white-space: pre-wrap;
+    &:hover {
+      color: $co-color__fg__text--high;
+    }
+  }
+
+  &__body {
+    padding: 0 $co-margin;
+    white-space: pre-wrap;
+  }
 }


### PR DESCRIPTION
**Design change**:
- Move author and summary into a lighter header
- Remove subject
- Simplify message responsive behaviour (so remove BS `.row`)
- Remove too low transition (can maybe added later on the whole
application)
- Fix some display bug

**SCSS clean**:
- Use `.co-list` and `co-text--ellipsis` instead of a custom list
- Use `co-` prefix instead of `caliopen-`
- Remove unused properties and classes
- Use standard margin values instead of magic numbers
- Make each component declare its only own internal margins. Use
"one-direction margin" consensus for external margins

:warning: **Require**:
- [x] https://github.com/CaliOpen/caliopen.web-client-ng/pull/42

**Previews PC**:
![Preview PC 1](http://img15.hostingpics.net/pics/142594ScreenShot20160308at054853.png)
![Preview PC 2](http://img15.hostingpics.net/pics/190284ScreenShot20160308at054831.png)

**Preview mobile**
![Preview mobile](http://img15.hostingpics.net/pics/746767ScreenShot20160308at054930.png)