### PR TITLE
refactor(contact): move contact out of contact list

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -73,6 +73,7 @@ app
 // directives
 import {ContactDirective} from './directive/contact.js';
 import {ContactsDirective} from './directive/contacts.js';
+import {ContactsContactDirective} from './directive/contacts/contact.js';
 import {DiscussionsDirective} from './directive/discussions.js';
 import {DiscussionsContactsIconDirective} from './directive/discussions/contacts-icon.js';
 import {DiscussionsThreadDirective} from './directive/discussions/thread.js';
@@ -91,6 +92,7 @@ import {WidgetContactAvatarLetterDirective} from './directive/widget/contact/ava
 app
   .directive('coContact', ContactDirective)
   .directive('coContacts', ContactsDirective)
+  .directive('coContactsContact', ContactsContactDirective)
   .directive('coDiscussions', DiscussionsDirective)
   .directive('coDiscussionsContactsIcon', DiscussionsContactsIconDirective)
   .directive('coDiscussionsThread', DiscussionsThreadDirective)

--- a/src/js/directive/contacts.js
+++ b/src/js/directive/contacts.js
@@ -1,30 +1,16 @@
 import {createSelector} from 'reselect';
-import {v1 as uuidV1} from 'uuid';
 
-const contactSelector = createSelector(
+const contactsSelector = createSelector(
   state => state.contactReducer,
   payload => {
     return { contacts: payload.contacts };
   });
 
 export class ContactsController {
-  constructor($scope, $ngRedux, ContactsActions, TabsActions) {
+  constructor($scope, $ngRedux, ContactsActions) {
     'ngInject';
-    this.$ngRedux = $ngRedux;
-    this.TabsActions = TabsActions;
-    $scope.$on('$destroy', $ngRedux.connect(contactSelector)(this));
+    $scope.$on('$destroy', $ngRedux.connect(contactsSelector)(this));
     $ngRedux.dispatch(ContactsActions.fetchContacts());
-  }
-
-  showContact(contact) {
-    this.$ngRedux.dispatch(dispatch => {
-      dispatch(this.TabsActions.addTab({
-        id: uuidV1(),
-        route: 'front.contacts.contact',
-        routeOpts: { contactId: contact.contact_id },
-        label: contact.title
-      }));
-    });
   }
 }
 
@@ -36,35 +22,8 @@ export function ContactsDirective() {
     controllerAs: 'ctrl',
     bindToController: true,
     template: `
-    <div class="container-fluid co-list">
-      <div ng-repeat="contact in ctrl.contacts" ng-click="ctrl.showContact(contact)" class="row co-list__item co-list__item--link">
-        <div class="row__vertical-align">
-          <div class="col-xs-12 col-sm-5">
-            <span class="co-contacts__contact-icon">
-              <widget-contact-avatar-letter contact="contact"></widget-contact-avatar-letter>
-            </span>
-            <span class="co-text--ellipsis">
-              {{contact.title}}
-            </span>
-          </div>
-          <div class="hidden-xs col-sm-7">
-            <span class="co-text--ellipsis">
-              {{contact.emails[0]}}
-            </span>
-            <span class="dropdown">
-              <span class="dropdown-toggle" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                <span class="caret"></span>
-              </span>
-              <ul class="dropdown-menu pull-right">
-                <li ng-repeat="email in contact.emails">
-                  <i class="fa fa-envelope"></i>
-                  {{email.address}}
-                </li>
-              </ul>
-            </span>
-          </div>
-        </div>
-      </div>
-    </div>`
+      <div class="container-fluid co-list">
+        <co-contacts-contact ng-repeat="contact in ctrl.contacts" contact="contact"></co-contacts-contact>
+      </div>`
   };
 }

--- a/src/js/directive/contacts/contact.js
+++ b/src/js/directive/contacts/contact.js
@@ -1,0 +1,61 @@
+import {v1 as uuidV1} from 'uuid';
+
+export class ContactsContactController {
+  constructor($ngRedux, TabsActions) {
+    'ngInject';
+    this.$ngRedux = $ngRedux;
+    this.TabsActions = TabsActions;
+  }
+
+  showContact() {
+    this.$ngRedux.dispatch(dispatch => {
+      dispatch(this.TabsActions.addTab({
+        id: uuidV1(),
+        route: 'front.contacts.contact',
+        routeOpts: { contactId: this.contact.contact_id },
+        label: this.contact.title
+      }));
+    });
+  }
+}
+
+export function ContactsContactDirective() {
+  return {
+    restrict: 'E',
+    scope: {
+      contact: '='
+    },
+    controller: ContactsContactController,
+    controllerAs: 'ctrl',
+    bindToController: true,
+    template: `
+      <div ng-click="ctrl.showContact()" class="row co-list__item co-list__item--link">
+        <div class="row__vertical-align">
+          <div class="col-xs-12 col-sm-5">
+            <span class="co-contacts__contact-icon">
+              <widget-contact-avatar-letter contact="ctrl.contact"></widget-contact-avatar-letter>
+            </span>
+            <span class="co-text--ellipsis">
+              {{ ctrl.contact.title }}
+            </span>
+          </div>
+          <div class="hidden-xs col-sm-7">
+            <span class="co-text--ellipsis">
+              {{ ctrl.contact.emails[0] }}
+            </span>
+            <span class="dropdown">
+              <span class="dropdown-toggle" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                <span class="caret"></span>
+              </span>
+              <ul class="dropdown-menu pull-right">
+                <li ng-repeat="email in ctrl.contact.emails">
+                  <i class="fa fa-envelope"></i>
+                  {{email.address}}
+                </li>
+              </ul>
+            </span>
+          </div>
+        </div>
+      </div>`
+  };
+}

--- a/src/styles/component/_list.scss
+++ b/src/styles/component/_list.scss
@@ -1,14 +1,12 @@
 .co-list {
+  border-top: 1px solid $body-bg;
+
   &__item {
     padding: 10px 0;
 
     background-color: $co-color__fg__back;
     border-bottom: 1px solid $body-bg;
     color: $co-color__fg__text;
-
-    &:first-child {
-      border-top: 1px solid $body-bg;
-    }
   }
 
   a.co-list__item,

--- a/test/unit/directive/contacts/contact-spec.js
+++ b/test/unit/directive/contacts/contact-spec.js
@@ -1,0 +1,2 @@
+describe('Directive Contacts Contact', () => {
+});


### PR DESCRIPTION
Move contact out of contact list `co-contacts` as
`co-contacts-contact`, because of the others list items which are out of
the list itself (`co-discussions-thread` and `co-thread-message`).

Note : need a renaming, to choose between `discussion` and `thread`,
and use `-list` suffix instead of plural

Other changes:
- Fix `co-list` border when `co-list__item` isn't a direct child