### PR TITLE
chore(various): make git ignore tmp/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist
 node_modules
 npm-debug.log
+tmp


### PR DESCRIPTION
Make git ignore `tmp/` folder.
`tmp/` is used to build scss.