### PR TITLE
fix(discussions): prevent thread time to break

### DIFF
--- a/src/js/directive/discussions/thread.js
+++ b/src/js/directive/discussions/thread.js
@@ -50,7 +50,10 @@ export function DiscussionsThreadDirective() {
           <i class="fa fa-eye"></i> {{ctrl.thread.privacy_index}}
         </div>
         <div class="col-md-2 col-sm-2 hidden-xs">
-          {{ ctrl.fakeDate | amDateFormat:'lll'}}
+          <time title="{{ ctrl.fakeDate | amDateFormat: 'LLL' }}">
+            <span class="co-text--ellipsis">{{ ctrl.fakeDate | amDateFormat: 'll' }}</span>
+            <span class="co-text--ellipsis">{{ ctrl.fakeDate | amDateFormat: 'LT' }}</span>
+          </time>
         </div>
         <div class="col-md-1 hidden-sm hidden-xs">
           <span class="co-threads__thread__nb-messages badge">

--- a/src/styles/component/_text.scss
+++ b/src/styles/component/_text.scss
@@ -1,5 +1,7 @@
-.co-text--ellipsis {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
+.co-text {
+  &--ellipsis {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
 }


### PR DESCRIPTION
Allow datetime to break only between date and time.

So we have **on PC**

    May 7, 2016 9:35 AM

**On tablet**

    May 7, 2016
    9:35 AM

**On mobile**: date is already hidden