### PR TITLE
fix(design): font was not correctly loaded + del compass-mixins

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "babel-polyfill": "^6.3.14",
     "babel-preset-es2015": "^6.1.18",
     "check-deps": "^1.4.0",
-    "compass-mixins": "^0.12.7",
     "concurrently": "^2.0.0",
     "del": "^2.1.0",
     "eslint": "^2.3.0",

--- a/src/styles/base/_fonts.scss
+++ b/src/styles/base/_fonts.scss
@@ -1,10 +1,11 @@
-@include font-face(
-  'open_sansregular',
-  font-files(
-    '../fonts/Open_Sans/opensans-regular-webfont.eot',
-    '../fonts/Open_Sans/opensans-regular-webfont.woff2',
-    '../fonts/Open_Sans/opensans-regular-webfont.woff',
-    '../fonts/Open_Sans/opensans-regular-webfont.ttf',
-    '../fonts/Open_Sans/opensans-regular-webfont.svg'
-  )
-);
+@font-face {
+  font-family: 'open_sansregular';
+  src: url('../fonts/Open_Sans/opensans-regular-webfont.eot');
+  src: url('../fonts/Open_Sans/opensans-regular-webfont.eot?#iefix') format('embedded-opentype'),
+       url('../fonts/Open_Sans/opensans-regular-webfont.woff2') format('woff2'),
+       url('../fonts/Open_Sans/opensans-regular-webfont.woff') format('woff'),
+       url('../fonts/Open_Sans/opensans-regular-webfont.ttf') format('truetype'),
+       url('../fonts/Open_Sans/opensans-regular-webfont.svg#open_sansregular') format('svg');
+  font-weight: normal;
+  font-style: normal;
+}

--- a/src/styles/layout/_l-topbar.scss
+++ b/src/styles/layout/_l-topbar.scss
@@ -3,7 +3,10 @@
   max-width: none;
   margin-bottom: 15px;
 
-  &__col-action { @include flex-grid-column(12); }
+  &__col-action {
+    white-space: nowrap;
+    @include flex-grid-column(12);
+  }
   &__col-slider { @include flex-grid-column(12); }
 
   @include breakpoint(medium) {

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -8,7 +8,6 @@
 @import 'vendor/foundation-sites/config';
 @import 'vendor/foundation-sites/flex-grid';
 @import 'vendor/foundation-sites';
-@import 'vendor/compass-mixins/compass';
 
 @import 'font-awesome/scss/font-awesome';
 

--- a/src/styles/vendor/compass-mixins/_compass.scss
+++ b/src/styles/vendor/compass-mixins/_compass.scss
@@ -1,1 +1,0 @@
-@import 'compass-mixins/lib/compass/css3/font-face';

--- a/src/styles/vendor/foundation-sites/_config.scss
+++ b/src/styles/vendor/foundation-sites/_config.scss
@@ -65,7 +65,7 @@ $foundation-palette: (
 // $white: #fefefe;
 $body-background: $co-color__bg__back;
 $body-font-color: $co-color__bg__text;
-// $body-font-family: 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif;
+$body-font-family: 'open_sansregular', 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif;
 // $body-antialiased: true;
 // $global-margin: 1rem;
 // $global-padding: 1rem;


### PR DESCRIPTION
font-files is a compass sass extension for ruby: http://compass-style.org/reference/compass/helpers/font-files/#font-files, font-face mixin isn't useful anymore

+ prevent line breaks in action button